### PR TITLE
Fix multiple `#include`s not working

### DIFF
--- a/src/TTSAdapter.js
+++ b/src/TTSAdapter.js
@@ -123,7 +123,7 @@ class TTSAdapter {
   _uncompressIncludes (luaScript, baseFolder, includePath, alreadyInserted) {
     alreadyInserted = alreadyInserted || []
     let insertLuaFileRegexp = RegExp('^(\\s*%include\\s+([^\\s].*))', 'm')
-    luaScript = luaScript.replace('#include ', '%include ')
+    luaScript = luaScript.replace(/#include /g, '%include ')
     while (true) {
       let match = luaScript.match(insertLuaFileRegexp)
       if (match === null) break


### PR DESCRIPTION
Fixes #4 

Only the first `#include ` was being replaced by the call to `replace`. Updated with a regex to replace all `#include `s in the script.

As a temporary workaround, until this is merged, you can just use `%include` in your script instead of `#include`.