### PR TITLE
Add "Go To Error" option when receiving a TTS error.

### DIFF
--- a/src/TTSAdapter.ts
+++ b/src/TTSAdapter.ts
@@ -299,8 +299,8 @@ export default class TTSAdapter {
    * @param message - Error Message received from TTS
    */
   private async goToTTSError(message: TTSMessage): Promise<TextEditor | undefined> {
-    const text = message.errorMessagePrefix! + message.error!;
-    const re = /:\((?<line>\d*),(?<startChar>\d*)-(?<endChar>\d*)\):/;
+    const text = message.errorMessagePrefix!;
+    const re = /.*:\((?<line>\d*),(?<startChar>\d*)-(?<endChar>\d*)\):/;
     const m = re.exec(message.error!);
     if (!m) { // not a jumpable error message, just show it
       wd.showErrorMessage(text);


### PR DESCRIPTION
Shows a vscode error box when a TTS error is received including a button to open the relevant file and highlight the relevant section. Works for bundled and unbundled files.

Jumping to a bundled error is handled by caching the last set of scripts sent and unbundling the file with the relevant GUID on demand. Unbundling could be skipped if luabundle gave us the metadata we need when bundling, but this seems like the simplest solution until something changes there.