### PR TITLE
Add support for symlink workspace directory

### DIFF
--- a/src/TTSAdapter.ts
+++ b/src/TTSAdapter.ts
@@ -20,7 +20,7 @@ import { resolveModule } from 'luabundle/bundle/process';
 import { readFileSync, readlinkSync } from 'fs';
 
 import parse from './bbcode/tabletop';
-import { tempFolder, docsFolder, FileHandler, isTempFolder } from './filehandler';
+import { tempFolder, docsFolder, FileHandler } from './filehandler';
 
 /**
  * Shape of data received from TTS
@@ -146,12 +146,26 @@ export default class TTSAdapter {
     this.server.listen(port, 'localhost'); // Open Server
   }
 
+  private isTempFolder(dir: Uri) {
+    if (dir.uri.fsPath === this.tempUri.fsPath) {
+      return true;
+    }
+
+    try {
+      let resolvedSymlink = readlinkSync(dir)
+      return resolvedSymlink === this.tempUri.fsPath;
+    }
+    catch (reason: any) {
+      return false;
+    }
+  }
+
   /**
    * Retrieves scripts from currently open savegame
    */
   public async getScripts() {
     const vsFolders = ws.workspaceFolders;
-    if (!vsFolders || vsFolders.findIndex((dir) => isTempFolder(dir.uri.fsPath)) {
+    if (!vsFolders || vsFolders.findIndex((dir) => this.isTempFolder(dir)) === -1) {
       ws.updateWorkspaceFolders(vsFolders ? vsFolders.length : 0, null, { uri: this.tempUri });
     }
     TTSAdapter.sendToTTS(TxMsgType.GetScripts);

--- a/src/TTSAdapter.ts
+++ b/src/TTSAdapter.ts
@@ -17,10 +17,10 @@ import { join, posix } from 'path';
 import bundle from 'luabundle';
 import { NoBundleMetadataError } from 'luabundle/errors';
 import { resolveModule } from 'luabundle/bundle/process';
-import { readFileSync } from 'fs';
+import { readFileSync, readlinkSync } from 'fs';
 
 import parse from './bbcode/tabletop';
-import { tempFolder, docsFolder, FileHandler } from './filehandler';
+import { tempFolder, docsFolder, FileHandler, isTempFolder } from './filehandler';
 
 /**
  * Shape of data received from TTS
@@ -151,7 +151,7 @@ export default class TTSAdapter {
    */
   public async getScripts() {
     const vsFolders = ws.workspaceFolders;
-    if (!vsFolders || vsFolders.findIndex((dir) => dir.uri.fsPath === this.tempUri.fsPath) === -1) {
+    if (!vsFolders || vsFolders.findIndex((dir) => isTempFolder(dir.uri.fsPath)) {
       ws.updateWorkspaceFolders(vsFolders ? vsFolders.length : 0, null, { uri: this.tempUri });
     }
     TTSAdapter.sendToTTS(TxMsgType.GetScripts);


### PR DESCRIPTION
Currently the extension requires the temp directory to be part of the workspace which is a problem when working with a team, as users will have different temp directories. The current solution is to resolve the path in the workspace, if it is a symlink (junction on windows) and determine if it matches the temp directory.