### PR TITLE
Fixed newline bug on reading files from TTS

### DIFF
--- a/src/TTSAdapter.ts
+++ b/src/TTSAdapter.ts
@@ -504,7 +504,7 @@ export default class TTSAdapter extends vscode.Disposable {
         }
         // Lua File Creation
         // First create the file as-is
-        const luaHandler = new ws.FileHandler(`${scriptState.name}.${scriptState.guid}.lua`);
+        const luaHandler = new ws.FileHandler(`${scriptState.name}.${scriptState.guid}.lua`.replace(/\n/gi, ''));
         await luaHandler.write(scriptState.script);
         try {
           // Then, attempt to unbundle


### PR DESCRIPTION
Added super basic catch to filter out newline characters from object names in TTS, which would cause the entire readFilesFromTTS operation to fail (because the file could not be created with a newline char in the name).